### PR TITLE
Allow configuring headers and URL for GitHub download

### DIFF
--- a/inc/class-importer.php
+++ b/inc/class-importer.php
@@ -256,8 +256,7 @@ abstract class Importer {
 		}
 
 		// Transform GitHub repo HTML pages into their raw equivalents
-		$markdown_source = preg_replace( '#https?://github\.com/([^/]+/[^/]+)/blob/(.+)#', 'https://raw.githubusercontent.com/$1/$2', $markdown_source );
-		$markdown_source = add_query_arg( 'v', time(), $markdown_source );
+		$markdown_source = $this->get_markdown_download_source( $markdown_source, $post_id );
 
 		// Grab the stored ETag, and use it to deduplicate.
 		$args = array(
@@ -329,6 +328,19 @@ abstract class Importer {
 		}
 
 		return $markdown_source;
+	}
+
+	/**
+	 * Convert the source URL to a download URL.
+	 *
+	 * @param string $source_url Source URL from {@see get_markdown_source}.
+	 * @param int    $post_id Post ID being fetched.
+	 * @return string URL to download source from.
+	 */
+	protected function get_markdown_download_source( $source_url, $post_id ) {
+		$source_url = preg_replace( '#https?://github\.com/([^/]+/[^/]+)/blob/(.+)#', 'https://raw.githubusercontent.com/$1/$2', $source_url );
+		$source_url = add_query_arg( 'v', time(), $source_url );
+		return $source_url;
 	}
 
 	/**

--- a/inc/class-importer.php
+++ b/inc/class-importer.php
@@ -261,7 +261,7 @@ abstract class Importer {
 
 		// Grab the stored ETag, and use it to deduplicate.
 		$args = array(
-			'headers' => array(),
+			'headers' => $this->get_markdown_source_headers( $post_id ),
 		);
 		$last_etag = get_post_meta( $post_id, $this->etag_meta_key, true );
 		if ( ! empty( $last_etag ) ) {
@@ -329,5 +329,15 @@ abstract class Importer {
 		}
 
 		return $markdown_source;
+	}
+
+	/**
+	 * Get headers to send to Markdown source URL.
+	 *
+	 * @param int $post_id Post ID being fetched.
+	 * @return array Headers to pass to wp_remote_request()
+	 */
+	protected function get_markdown_source_headers( $post_id ) {
+		return array();
 	}
 }

--- a/inc/class-importer.php
+++ b/inc/class-importer.php
@@ -85,7 +85,10 @@ abstract class Importer {
 	 * Fetches the manifest, parses, and creates pages as needed.
 	 */
 	public function import_manifest() {
-		$response = wp_remote_get( $this->get_manifest_url() );
+		$options = [
+			'headers' => $this->get_manifest_headers(),
+		];
+		$response = wp_remote_get( $this->get_manifest_url(), $options );
 		if ( is_wp_error( $response ) ) {
 			if ( class_exists( 'WP_CLI' ) ) {
 				WP_CLI::error( $response->get_error_message() );
@@ -350,6 +353,15 @@ abstract class Importer {
 	 * @return array Headers to pass to wp_remote_request()
 	 */
 	protected function get_markdown_source_headers( $post_id ) {
+		return array();
+	}
+
+	/**
+	 * Get headers to send to manifest URL.
+	 *
+	 * @return array Headers to pass to wp_remote_request()
+	 */
+	protected function get_manifest_headers() {
 		return array();
 	}
 }


### PR DESCRIPTION
For private APIs (like GitHub's), this allows sending authentication tokens/etc.

e.g. to use a private repo:
```
	public function get_markdown_source( $post_id ) {
		$source = parent::get_markdown_source( $post_id );
		if ( is_wp_error( $source ) ) {
			return $source;
		}

		// Send requests to the GH REST API, with our token.
		$source = preg_replace( '#https?://github\.com/([^/]+/[^/]+)/blob/([^/]+)/(.+)#', 'https://api.github.com/repos/$1/contents/$3?ref=$2', $source );
		$source = add_query_arg( 'access_token', ACCESS_TOKEN, $source );
		return $source;
	}

	protected function get_markdown_source_headers( $id ) {
		return [
			'Accept' => 'application/vnd.github.v3.raw',
		];
	}
```