### PR TITLE
Fix PHP 7.2 compatibility

### DIFF
--- a/inc/class-editor.php
+++ b/inc/class-editor.php
@@ -5,7 +5,7 @@ namespace WordPressdotorg\Markdown;
 use WP_Post;
 
 class Editor {
-	public Importer $importer;
+	public $importer;
 
 	public function __construct( Importer $importer ) {
 		$this->importer = $importer;


### PR DESCRIPTION
PHP 7.2 compatibility was inadvertently broken by adding this strongly-typed property.